### PR TITLE
자바 버전 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ group = 'com.palindrome'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '21'
+	sourceCompatibility = '17'
 }
 
 configurations {


### PR DESCRIPTION
java 21 버전의 레퍼런스 부족의 이유로 17 버전으로 변경합니다.