### PR TITLE
[STUD-83] mission url 수정 API

### DIFF
--- a/src/main/java/com/palindrome/studit/domain/study/api/StudyController.java
+++ b/src/main/java/com/palindrome/studit/domain/study/api/StudyController.java
@@ -3,6 +3,7 @@ package com.palindrome.studit.domain.study.api;
 import com.palindrome.studit.domain.study.application.StudyService;
 import com.palindrome.studit.domain.study.domain.Study;
 import com.palindrome.studit.domain.study.dto.CreateStudyDTO;
+import com.palindrome.studit.domain.study.dto.MissionUrlRequestDTO;
 import com.palindrome.studit.domain.study.dto.StudyResponseDTO;
 import com.palindrome.studit.domain.study.exception.DuplicatedStudyEnrollmentException;
 import jakarta.validation.Valid;
@@ -41,6 +42,12 @@ public class StudyController {
     public ResponseEntity<Object> enrollStudy(Authentication authentication, @PathVariable("studyId") Long studyId) throws DuplicatedStudyEnrollmentException {
         studyService.enroll(Long.parseLong(authentication.getName()), studyId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PatchMapping("/{studyId}/missions/url")
+    public ResponseEntity<Object> updateMissionurl(Authentication authentication, @PathVariable("studyId") Long studyId, @Valid @RequestBody MissionUrlRequestDTO missionUrlRequestDTO) {
+        studyService.updateMissionUrl(Long.parseLong(authentication.getName()), studyId, missionUrlRequestDTO);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
     @ExceptionHandler({ DuplicatedStudyEnrollmentException.class })

--- a/src/main/java/com/palindrome/studit/domain/study/application/StudyService.java
+++ b/src/main/java/com/palindrome/studit/domain/study/application/StudyService.java
@@ -4,9 +4,11 @@ import com.palindrome.studit.domain.study.dao.StudyEnrollmentRepository;
 import com.palindrome.studit.domain.study.dao.StudyRepository;
 import com.palindrome.studit.domain.study.domain.*;
 import com.palindrome.studit.domain.study.dto.CreateStudyDTO;
+import com.palindrome.studit.domain.study.dto.MissionUrlRequestDTO;
 import com.palindrome.studit.domain.study.exception.DuplicatedStudyEnrollmentException;
 import com.palindrome.studit.domain.user.dao.UserRepository;
 import com.palindrome.studit.domain.user.domain.User;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -17,7 +19,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -92,5 +96,28 @@ public class StudyService {
         }
 
         return studyEnrollment;
+    }
+
+    @Transactional
+    public void updateMissionUrl(Long userId, Long studyId, MissionUrlRequestDTO missionUrlRequestDTO) {
+        User user = userRepository.getReferenceById(userId);
+        Study study = studyRepository.findById(studyId).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 스터디입니다."));
+        String missionUrl = validateMissionUrl(study.getMission().getMissionType(), missionUrlRequestDTO.getMissionUrl());
+
+        StudyEnrollment studyEnrollment = studyEnrollmentRepository.findByUserAndStudy(user, study).orElseThrow(() -> new EntityNotFoundException("해당 스터디 참여 내역이 없습니다."));
+        studyEnrollment.updateMissionUrl(missionUrl);
+    }
+
+    public String validateMissionUrl(MissionType missionType, String missionUrl) {
+        final Map<MissionType, Pattern> missionTypeUrlMap = Map.of(
+                MissionType.GITHUB, Pattern.compile("https://github.com/\\w+"),
+                MissionType.VELOG, Pattern.compile("https://velog.io/@\\w+")
+        );
+
+        Pattern pattern = missionTypeUrlMap.get(missionType);
+        if (!pattern.matcher(missionUrl).matches()) {
+            throw new IllegalArgumentException("잘못된 주소입니다.");
+        }
+        return missionUrl;
     }
 }

--- a/src/main/java/com/palindrome/studit/domain/study/dao/StudyEnrollmentRepository.java
+++ b/src/main/java/com/palindrome/studit/domain/study/dao/StudyEnrollmentRepository.java
@@ -1,9 +1,14 @@
 package com.palindrome.studit.domain.study.dao;
 
+import com.palindrome.studit.domain.study.domain.Study;
 import com.palindrome.studit.domain.study.domain.StudyEnrollment;
+import com.palindrome.studit.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface StudyEnrollmentRepository extends JpaRepository<StudyEnrollment, Long> {
+    Optional<StudyEnrollment> findByUserAndStudy(User user, Study study);
 }

--- a/src/main/java/com/palindrome/studit/domain/study/domain/StudyEnrollment.java
+++ b/src/main/java/com/palindrome/studit/domain/study/domain/StudyEnrollment.java
@@ -29,4 +29,10 @@ public class StudyEnrollment extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private StudyRole role;
+
+    private String missionUrl;
+
+    public void updateMissionUrl(String missionUrl) {
+        this.missionUrl = missionUrl;
+    }
 }

--- a/src/main/java/com/palindrome/studit/domain/study/dto/CreateStudyDTO.java
+++ b/src/main/java/com/palindrome/studit/domain/study/dto/CreateStudyDTO.java
@@ -4,7 +4,6 @@ import com.palindrome.studit.domain.study.domain.MissionType;
 import com.palindrome.studit.domain.study.domain.StudyPurpose;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/palindrome/studit/domain/study/dto/MissionUrlRequestDTO.java
+++ b/src/main/java/com/palindrome/studit/domain/study/dto/MissionUrlRequestDTO.java
@@ -1,10 +1,14 @@
 package com.palindrome.studit.domain.study.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Builder
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class MissionUrlRequestDTO {
     private String missionUrl;
 }

--- a/src/main/java/com/palindrome/studit/domain/study/dto/MissionUrlRequestDTO.java
+++ b/src/main/java/com/palindrome/studit/domain/study/dto/MissionUrlRequestDTO.java
@@ -1,0 +1,2 @@
+package com.palindrome.studit.domain.study.dto;public class MissionUrlRequestDTO {
+}

--- a/src/main/java/com/palindrome/studit/domain/study/dto/MissionUrlRequestDTO.java
+++ b/src/main/java/com/palindrome/studit/domain/study/dto/MissionUrlRequestDTO.java
@@ -1,2 +1,10 @@
-package com.palindrome.studit.domain.study.dto;public class MissionUrlRequestDTO {
+package com.palindrome.studit.domain.study.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MissionUrlRequestDTO {
+    private String missionUrl;
 }

--- a/src/main/java/com/palindrome/studit/domain/user/api/AuthController.java
+++ b/src/main/java/com/palindrome/studit/domain/user/api/AuthController.java
@@ -1,20 +1,14 @@
 package com.palindrome.studit.domain.user.api;
 
 import com.palindrome.studit.domain.user.application.AuthService;
-import com.palindrome.studit.domain.user.dao.OAuthInfoRepository;
 import com.palindrome.studit.domain.user.dto.JwtDTO;
 import com.palindrome.studit.domain.user.dto.RefreshTokenDTO;
-import com.palindrome.studit.domain.user.entity.OAuthInfo;
 import com.palindrome.studit.domain.user.exception.InvalidTokenException;
 import com.palindrome.studit.global.config.security.application.TokenService;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Date;
 
 @RequiredArgsConstructor
 @RestController
@@ -24,7 +18,7 @@ public class AuthController {
     private final AuthService authService;
 
     @GetMapping("/token-info/{accessToken}")
-    public JwtDTO getJwtInfo(@PathVariable String accessToken) throws InvalidTokenException {
+    public JwtDTO getJwtInfo(@PathVariable("accessToken") String accessToken) throws InvalidTokenException {
         return JwtDTO.builder()
                 .sub(tokenService.parseSubject(accessToken))
                 .exp(tokenService.parseExpiration(accessToken))

--- a/src/main/java/com/palindrome/studit/global/error/ErrorResponse.java
+++ b/src/main/java/com/palindrome/studit/global/error/ErrorResponse.java
@@ -1,2 +1,14 @@
-package com.palindrome.studit.global.error;public class ErrorResponse {
+package com.palindrome.studit.global.error;
+
+import lombok.*;
+import org.springframework.http.HttpStatus;
+
+@Data
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private String code;
+    private String message;
+    private HttpStatus status;
+
 }

--- a/src/main/java/com/palindrome/studit/global/error/ErrorResponse.java
+++ b/src/main/java/com/palindrome/studit/global/error/ErrorResponse.java
@@ -1,0 +1,2 @@
+package com.palindrome.studit.global.error;public class ErrorResponse {
+}

--- a/src/main/java/com/palindrome/studit/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/palindrome/studit/global/error/GlobalExceptionHandler.java
@@ -1,2 +1,27 @@
-package com.palindrome.studit.global.error;public class GlobalExceptionHandler {
+package com.palindrome.studit.global.error;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handlerEntityNotFoundException(EntityNotFoundException e) {
+        log.error("handleEntityNotFoundException = {}", e.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse("handleEntityNotFoundException", e.getMessage(), HttpStatus.NOT_FOUND);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ErrorResponse> handlerIllegalArgumentException(IllegalArgumentException e) {
+        log.error("handlerIllegalArgumentException = {}", e.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse("handlerIllegalArgumentException", e.getMessage(), HttpStatus.BAD_REQUEST);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
 }

--- a/src/main/java/com/palindrome/studit/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/palindrome/studit/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,2 @@
+package com.palindrome.studit.global.error;public class GlobalExceptionHandler {
+}

--- a/src/test/java/com/palindrome/studit/domain/study/api/StudyControllerTest.java
+++ b/src/test/java/com/palindrome/studit/domain/study/api/StudyControllerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -21,6 +22,7 @@ import java.time.LocalDateTime;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -100,4 +102,46 @@ class StudyControllerTest {
                 .andExpect(jsonPath("$.total_elements").value(20));
 
     }
+
+    @Test
+    @DisplayName("미션 수행할 주소 수정 성공 테스트")
+    void updateMissionUrlTest() throws Exception {
+        //Given
+        User user = authService.createUser("test@email.com", OAuthProviderType.GITHUB, "providerId");
+        createStudies(user, true, 1);
+        String accessToken = tokenService.createAccessToken(user.getUserId().toString());
+
+        //When
+        String requestJson = "{\"mission_url\": \"https://github.com/palindrome\"}";
+        ResultActions mockResult = mockMvc.perform(patch("/studies/1/missions/url")
+                .header("Authorization", "Bearer " + accessToken)
+                .content(requestJson)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        //Then
+        mockResult.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("미션 수행할 주소 수정 실패 테스트")
+    void updateMissionUrlFailureTest() throws Exception {
+        //Given
+        User user = authService.createUser("test@email.com", OAuthProviderType.GITHUB, "providerId");
+        createStudies(user, true, 1);
+        String accessToken = tokenService.createAccessToken(user.getUserId().toString());
+
+        //When
+        String requestJson = "{\"mission_url\": \"https://velog.io/@palindrome\"}";
+        ResultActions mockResult = mockMvc.perform(patch("/studies/1/missions/url")
+                .header("Authorization", "Bearer " + accessToken)
+                .content(requestJson)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        //Then
+        mockResult
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("잘못된 주소입니다."));
+    }
+
+
 }

--- a/src/test/java/com/palindrome/studit/domain/study/application/StudyServiceTest.java
+++ b/src/test/java/com/palindrome/studit/domain/study/application/StudyServiceTest.java
@@ -7,11 +7,13 @@ import com.palindrome.studit.domain.study.domain.Study;
 import com.palindrome.studit.domain.study.domain.StudyEnrollment;
 import com.palindrome.studit.domain.study.domain.StudyPurpose;
 import com.palindrome.studit.domain.study.dto.CreateStudyDTO;
+import com.palindrome.studit.domain.study.dto.MissionUrlRequestDTO;
 import com.palindrome.studit.domain.study.exception.DuplicatedStudyEnrollmentException;
 import com.palindrome.studit.domain.user.application.AuthService;
 import com.palindrome.studit.domain.user.domain.OAuthProviderType;
 import com.palindrome.studit.domain.user.domain.User;
 import com.palindrome.studit.global.config.security.application.TokenService;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,8 +24,10 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DataJpaTest
@@ -218,5 +222,75 @@ class StudyServiceTest {
         //Then
         assertThat(studyEnrollment).isNotNull();
         assertThat(studyEnrollmentRepository.count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("미션 주소 수정 성공 테스트")
+    void updateMissionUrlTest() {
+        //Given
+        User user = authService.createUser("user@email.com", OAuthProviderType.GITHUB, "providerId1");
+        CreateStudyDTO createStudyDTO = CreateStudyDTO.builder()
+                .name("신규 스터디")
+                .startAt(LocalDateTime.now())
+                .endAt(LocalDateTime.now().plusDays(7))
+                .maxMembers(10L)
+                .purpose(StudyPurpose.ALGORITHM)
+                .description("테스트용 스터디입니다.")
+                .isPublic(false)
+                .missionType(MissionType.GITHUB)
+                .missionCountPerWeek(3)
+                .finePerMission(100_000)
+                .build();
+        Study study = studyService.createStudy(user.getUserId(), createStudyDTO);
+        MissionUrlRequestDTO missionUrlRequestDTO = MissionUrlRequestDTO.builder()
+                .missionUrl("https://github.com/username").build();
+
+        //When
+        studyService.updateMissionUrl(user.getUserId(), study.getStudyId(), missionUrlRequestDTO);
+
+        //Then
+        Optional<StudyEnrollment> optionalStudyEnrollment = studyEnrollmentRepository.findByUserAndStudy(user, study);
+        StudyEnrollment studyEnrollment = optionalStudyEnrollment.get();
+        assertThat(studyEnrollment.getMissionUrl().equals(missionUrlRequestDTO.getMissionUrl()));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 스터디에 대한 미션 주소 수정 실패 테스트")
+    void updateMissionUrlForNonExistingStudyTest() {
+        User user = authService.createUser("user@email.com", OAuthProviderType.GITHUB, "providerId1");
+        Long nonExistingStudyId = 1000L;
+        MissionUrlRequestDTO missionUrlRequestDTO = MissionUrlRequestDTO.builder()
+                .missionUrl("https://github.com/username").build();
+
+        //When, Then
+        assertThrows(EntityNotFoundException.class, () -> {studyService.updateMissionUrl(user.getUserId(), nonExistingStudyId, missionUrlRequestDTO);});
+    }
+
+    @Test
+    @DisplayName("참여 내역 없는 스터디 미션 수정 실패 테스트")
+    void updateMissionUrlNonExistingStudyEnrollmentTest() {
+        //Given
+        User studyLeader = authService.createUser("test@email.com", OAuthProviderType.GITHUB, "providerId1");
+        User user = authService.createUser("user@email.com", OAuthProviderType.GITHUB, "providerId1");
+        CreateStudyDTO createStudyDTO = CreateStudyDTO.builder()
+                .name("신규 스터디")
+                .startAt(LocalDateTime.now())
+                .endAt(LocalDateTime.now().plusDays(7))
+                .maxMembers(10L)
+                .purpose(StudyPurpose.ALGORITHM)
+                .description("테스트용 스터디입니다.")
+                .isPublic(false)
+                .missionType(MissionType.GITHUB)
+                .missionCountPerWeek(3)
+                .finePerMission(100_000)
+                .build();
+        Study study = studyService.createStudy(studyLeader.getUserId(), createStudyDTO);
+        MissionUrlRequestDTO missionUrlRequestDTO = MissionUrlRequestDTO.builder()
+                .missionUrl("https://github.com/username").build();
+
+        //When, Then
+        assertThrows(EntityNotFoundException.class, () -> {
+            studyService.updateMissionUrl(user.getUserId(), study.getStudyId(), missionUrlRequestDTO);
+        });
     }
 }

--- a/src/test/java/com/palindrome/studit/domain/study/application/StudyServiceTest.java
+++ b/src/test/java/com/palindrome/studit/domain/study/application/StudyServiceTest.java
@@ -293,4 +293,66 @@ class StudyServiceTest {
             studyService.updateMissionUrl(user.getUserId(), study.getStudyId(), missionUrlRequestDTO);
         });
     }
+
+    @Test
+    @DisplayName("github 미션 주소 검증 테스트")
+    void validateGithubMissionUrlTest() {
+        //Given
+        MissionType missionTypeGithub = MissionType.GITHUB;
+        String githubTestUrl = "https://github.com/username";
+
+        //When
+        String githubMissionUrl = studyService.validateMissionUrl(missionTypeGithub, githubTestUrl);
+
+        //Then
+        assertEquals(githubTestUrl, githubMissionUrl);
+    }
+
+    @Test
+    @DisplayName("velog 미션 주소 검증 테스트")
+    void validateVelogMissionUrlTest() {
+        //Given
+        MissionType missionTypeVelog = MissionType.VELOG;
+        String velogTestUrl = "https://velog.io/@username";
+
+        //When
+        String velogMissionUrl = studyService.validateMissionUrl(missionTypeVelog, velogTestUrl);
+
+        //Then
+        assertEquals(velogTestUrl, velogMissionUrl);
+    }
+
+    @Test
+    @DisplayName("velog 미션 주소 검증 실패 테스트")
+    void validateVelogMissionUrlFailureTest() {
+        //Given
+        MissionType missionTypeVelog = MissionType.VELOG;
+        String velogTestUrl = "https://velog.io/username";
+        String githubTestUrl = "https://github.com/username";
+
+        //When, Then
+        assertThrows(IllegalArgumentException.class, () -> {
+            studyService.validateMissionUrl(missionTypeVelog, githubTestUrl);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            studyService.validateMissionUrl(missionTypeVelog, velogTestUrl);
+        });
+    }
+
+    @Test
+    @DisplayName("github 미션 주소 검증 실패 테스트")
+    void validateGithubMissionUrlFailureTest() {
+        // Given
+        MissionType missionTypeGithub = MissionType.GITHUB;
+        String githubTestUrl = "https://github.com/@username";
+        String velogTestUrl = "https://velog.io/@username";
+
+        // When, Then
+        assertThrows(IllegalArgumentException.class, () -> {
+            studyService.validateMissionUrl(missionTypeGithub, velogTestUrl);
+        });
+        assertThrows(IllegalArgumentException.class, () -> {
+            studyService.validateMissionUrl(missionTypeGithub, githubTestUrl);
+        });
+    }
 }


### PR DESCRIPTION
1. mission url 수정 API 추가합니다.
mission url은 velog, github의 경우 시작 주소만 확인합니다.
2. mission url 수정 API 테스트 추가합니다.
3. global exception handler 추가합니다.
4. 사용하지 않는 import 삭제합니다.